### PR TITLE
Exclude E2 files

### DIFF
--- a/gluafixer/glualint.json
+++ b/gluafixer/glualint.json
@@ -22,7 +22,7 @@
     "lint_spaceAfterParens":            true,
     "lint_spaceAfterBrackets":          true,
     "lint_spaceAfterBraces":            true,
-    "lint_ignoreFiles":                 [],
+    "lint_ignoreFiles":                 ["lua/entities/gmod_wire_expression2/core/custom/*"],,
 
     "prettyprint_spaceAfterParens":     true,
     "prettyprint_spaceAfterBrackets":   false,


### PR DESCRIPTION
This feature is currently kinda broken sadly but im making this or to be available once the ignorefiles works again.
https://github.com/FPtje/GLuaFixer/issues/136 shows that this is broken.
 